### PR TITLE
Replace a TAB character in phpstan.common.neon

### DIFF
--- a/phpstan.common.neon
+++ b/phpstan.common.neon
@@ -1,5 +1,5 @@
 includes:
-	- vendor/phpstan/phpstan/conf/bleedingEdge.neon
+    - vendor/phpstan/phpstan/conf/bleedingEdge.neon
 parameters:
     tmpDir: .phpstan-cache
     level: 8


### PR DESCRIPTION
TAB-s are for typewriters (and the Go language)

@TamasSzigeti 